### PR TITLE
chore: add Frappe v16 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0,<17.0.0"
+
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"


### PR DESCRIPTION
Adds Frappe v16 compatibility metadata to Workboard by updating the Frappe dependency version range in pyproject.toml.

**Changes**

Added Frappe dependency compatibility:

[tool.bench.frappe-dependencies]
frappe = ">=15.0.0,<17.0.0"
Expanded supported versions to include Frappe v16 while retaining v15 compatibility.

**Reason**

The app currently appears as incompatible on Frappe Cloud v16 because the compatibility range does not include Frappe v16.